### PR TITLE
Increase timeout for golangci-lint

### DIFF
--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           version: v1.60.1
           only-new-issues: true
+          args: --timeout=3m
   check-fmt:
     needs:
       - get-go-version


### PR DESCRIPTION
### Description
The golangci-lint is getting timeout due to potentially large no of dependencies. Increasing the timeout to 3m (previously 1m) to test.

