### PR TITLE
Fix the slug name as per docs structure

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -9,6 +9,6 @@ integration {
   component {
     type = "builder"
     name = "KubeVirt ISO"
-    slug = "kubevirt-iso"
+    slug = "iso"
   }
 }


### PR DESCRIPTION
### Description
The dir structure for docs is currently as follows:
docs > builders > iso.mdx

Hence the slug name should be `iso` instead of `kubevirt-iso`.

