### PR TITLE
Remove flags from metadata

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -5,7 +5,6 @@ integration {
   name = "KubeVirt"
   description = "The KubeVirt plugin can be used with HashiCorp Packer to create KubeVirt images."
   identifier = "packer/hashicorp/kubevirt"
-  flags = [""]
   component {
     type = "builder"
     name = "KubeVirt ISO"


### PR DESCRIPTION
### Description
the flag option is unnecessary since its empty. This is causing issues during the website integration

