### PR TITLE
fix the url reference to iso builder page

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -32,4 +32,4 @@ $ packer plugins install github.com/hashicorp/kubevirt
 
 #### Builders
 
-- [kubevirt-iso](/packer/integrations/hashicorp/kubevirt/latest/components/builder/kubevirt-iso) - This builder starts from a ISO file and builds virtual machine image on a KubeVirt cluster.
+- [kubevirt-iso](/packer/integrations/hashicorp/kubevirt/latest/components/builder/iso) - This builder starts from a ISO file and builds virtual machine image on a KubeVirt cluster.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,4 +32,4 @@ $ packer plugins install github.com/hashicorp/kubevirt
 
 #### Builders
 
-- [kubevirt-iso](/packer/integrations/hashicorp/kubevirt/latest/components/builder/kubevirt-iso) - This builder starts from a ISO file and builds virtual machine image on a KubeVirt cluster.
+- [kubevirt-iso](/packer/integrations/hashicorp/kubevirt/latest/components/builder/iso) - This builder starts from a ISO file and builds virtual machine image on a KubeVirt cluster.


### PR DESCRIPTION
### Description
The url reference to the kubevirt iso builder page was incorrect.

