### PR TITLE
fix: immediate binding for dv (#43)

### DIFF
--- a/builder/kubevirt/iso/resources.go
+++ b/builder/kubevirt/iso/resources.go
@@ -17,6 +17,8 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
+const immediateBindingAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
+
 func configMap(name string, mediaFiles []string) (*corev1.ConfigMap, error) {
 	data := make(map[string]string)
 
@@ -138,6 +140,9 @@ func cloneVolume(name, namespace, diskSize string) *cdiv1.DataVolume {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Annotations: map[string]string{
+				immediateBindingAnnotation: "true",
+			},
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: &cdiv1.DataVolumeSource{

--- a/builder/kubevirt/iso/step_create_bootablevolume_test.go
+++ b/builder/kubevirt/iso/step_create_bootablevolume_test.go
@@ -79,6 +79,10 @@ var _ = Describe("StepCreateBootableVolume", func() {
 			cdiClient.PrependReactor("create", "datavolumes", func(action testing.Action) (bool, runtime.Object, error) {
 				create := action.(testing.CreateAction)
 				dv := create.GetObject().(*cdiv1beta1.DataVolume)
+				Expect(dv.Annotations).To(HaveKeyWithValue(
+					"cdi.kubevirt.io/storage.bind.immediate.requested",
+					"true",
+				))
 				dv.Status.Phase = cdiv1beta1.Succeeded
 
 				// Important: store DV in the fake client's tracker


### PR DESCRIPTION
### Description
allow immediate binding for dv, this caused a deadlock which resulted in build to be stuck.
the final image DataVolume is created without requesting immediate binding, while Packer waits for it before creating a consumer
