### PR TITLE
HCP Packer Registry Support + CD-ROM Bus Portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ packer-plugin-kubevirt
 **/packer_log*.txt
 **/git_*test.pkr.hcl
 crash.log
-
+temp/
 dist/*
 .docs/*
 docs.zip

--- a/builder/kubevirt/iso/artifact.go
+++ b/builder/kubevirt/iso/artifact.go
@@ -3,8 +3,20 @@
 
 package iso
 
+import (
+	"fmt"
+
+	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
+)
+
 type Artifact struct {
+	// Name is the DataSource name of the bootable volume.
 	Name string
+	// Namespace is the Kubernetes namespace the DataSource lives in.
+	Namespace string
+	// StateData holds generated_data and any other state shared with
+	// post-processors and HCP Packer.
+	StateData map[string]any
 }
 
 func (a *Artifact) BuilderId() string {
@@ -15,16 +27,45 @@ func (a *Artifact) Files() []string {
 	return nil
 }
 
+// Id returns a namespace-qualified identifier so HCP Packer can track the
+// artifact unambiguously across clusters.
 func (a *Artifact) Id() string {
-	return a.Name
+	return fmt.Sprintf("%s/%s", a.Namespace, a.Name)
 }
 
 func (a *Artifact) String() string {
-	return a.Name
+	return fmt.Sprintf("Bootable volume: %s/%s", a.Namespace, a.Name)
 }
 
-func (a *Artifact) State(name string) interface{} {
-	return nil
+// State returns HCP Packer registry metadata when queried with
+// registryimage.ArtifactStateURI, and falls back to StateData for all other keys.
+// Reading from a nil map is safe and returns nil.
+func (a *Artifact) State(name string) any {
+	if name == registryimage.ArtifactStateURI {
+		return a.hcpRegistryMetadata()
+	}
+	return a.StateData[name]
+}
+
+func (a *Artifact) hcpRegistryMetadata() any {
+	labels := map[string]any{
+		"namespace": a.Namespace,
+	}
+
+	if genData, ok := a.StateData["generated_data"].(map[string]any); ok {
+		for k, v := range genData {
+			if s, ok := v.(string); ok {
+				labels[k] = s
+			}
+		}
+	}
+
+	img, _ := registryimage.FromArtifact(a,
+		registryimage.WithProvider("kubevirt"),
+		registryimage.WithRegion(a.Namespace),
+		registryimage.SetLabels(labels),
+	)
+	return img
 }
 
 func (a *Artifact) Destroy() error {

--- a/builder/kubevirt/iso/artifact_test.go
+++ b/builder/kubevirt/iso/artifact_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) Red Hat, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iso
+
+import (
+	"testing"
+
+	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
+	"github.com/mitchellh/mapstructure"
+)
+
+func TestArtifact_BuilderId(t *testing.T) {
+	a := &Artifact{Name: "my-image", Namespace: "images"}
+	if got := a.BuilderId(); got != "packer.kubevirt.iso" {
+		t.Errorf("BuilderId() = %q, want %q", got, "packer.kubevirt.iso")
+	}
+}
+
+func TestArtifact_Id(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		imageName string
+		want      string
+	}{
+		{"both set", "images", "my-image", "images/my-image"},
+		{"empty namespace", "", "my-image", "/my-image"},
+		{"empty name", "images", "", "images/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Artifact{Name: tt.imageName, Namespace: tt.namespace}
+			if got := a.Id(); got != tt.want {
+				t.Errorf("Id() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestArtifact_String(t *testing.T) {
+	a := &Artifact{Name: "my-image", Namespace: "images"}
+	want := "Bootable volume: images/my-image"
+	if got := a.String(); got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestArtifact_Files(t *testing.T) {
+	a := &Artifact{}
+	if files := a.Files(); files != nil {
+		t.Errorf("Files() = %v, want nil", files)
+	}
+}
+
+func TestArtifact_Destroy(t *testing.T) {
+	a := &Artifact{}
+	if err := a.Destroy(); err != nil {
+		t.Errorf("Destroy() = %v, want nil", err)
+	}
+}
+
+// decodeRegistryImage is a test helper that asserts result is a non-nil
+// *registryimage.Image and decodes it.
+func decodeRegistryImage(t *testing.T, result any) registryimage.Image {
+	t.Helper()
+	if result == nil {
+		t.Fatal("State(ArtifactStateURI) returned nil")
+	}
+	var img registryimage.Image
+	if err := mapstructure.Decode(result, &img); err != nil {
+		t.Fatalf("mapstructure.Decode: %v", err)
+	}
+	return img
+}
+
+func TestArtifact_State_HCP(t *testing.T) {
+	tests := []struct {
+		name          string
+		artifact      *Artifact
+		wantImageID   string
+		wantProvider  string
+		wantRegion    string
+		wantLabels    map[string]string
+	}{
+		{
+			name: "no generated_data",
+			artifact: &Artifact{
+				Name:      "my-image",
+				Namespace: "images",
+				StateData: map[string]any{},
+			},
+			wantImageID:  "images/my-image",
+			wantProvider: "kubevirt",
+			wantRegion:   "images",
+			wantLabels:   map[string]string{"namespace": "images"},
+		},
+		{
+			name: "with generated_data",
+			artifact: &Artifact{
+				Name:      "my-image",
+				Namespace: "images",
+				StateData: map[string]any{
+					"generated_data": map[string]any{
+						"BootableVolumeName": "my-image",
+					},
+				},
+			},
+			wantImageID:  "images/my-image",
+			wantProvider: "kubevirt",
+			wantRegion:   "images",
+			wantLabels: map[string]string{
+				"namespace":          "images",
+				"BootableVolumeName": "my-image",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.artifact.State(registryimage.ArtifactStateURI)
+			img := decodeRegistryImage(t, result)
+
+			if img.ImageID != tt.wantImageID {
+				t.Errorf("ImageID = %q, want %q", img.ImageID, tt.wantImageID)
+			}
+			if img.ProviderName != tt.wantProvider {
+				t.Errorf("ProviderName = %q, want %q", img.ProviderName, tt.wantProvider)
+			}
+			if img.ProviderRegion != tt.wantRegion {
+				t.Errorf("ProviderRegion = %q, want %q", img.ProviderRegion, tt.wantRegion)
+			}
+			for k, want := range tt.wantLabels {
+				if got := img.Labels[k]; got != want {
+					t.Errorf("Labels[%q] = %q, want %q", k, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestArtifact_State_OtherKeys(t *testing.T) {
+	tests := []struct {
+		name      string
+		stateData map[string]any
+		key       string
+		want      any
+	}{
+		{
+			name:      "known key returns value",
+			stateData: map[string]any{"some_key": "some_value"},
+			key:       "some_key",
+			want:      "some_value",
+		},
+		{
+			name:      "missing key returns nil",
+			stateData: map[string]any{},
+			key:       "missing_key",
+			want:      nil,
+		},
+		{
+			name:      "nil StateData returns nil",
+			stateData: nil,
+			key:       "any_key",
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Artifact{StateData: tt.stateData}
+			if got := a.State(tt.key); got != tt.want {
+				t.Errorf("State(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}

--- a/builder/kubevirt/iso/builder.go
+++ b/builder/kubevirt/iso/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 
 	"k8s.io/client-go/kubernetes"
@@ -60,10 +61,16 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		return nil, warnings, fmt.Errorf("failed to create Kubernetes clientset: %w", err)
 	}
 	b.clientset = clientset
-	return nil, warnings, nil
+	return []string{"BootableVolumeName"}, warnings, nil
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
+	state := new(multistep.BasicStateBag)
+	state.Put("hook", hook)
+	state.Put("ui", ui)
+
+	generatedData := &packerbuilderdata.GeneratedData{State: state}
+
 	steps := []multistep.Step{}
 	steps = append(steps,
 		&StepValidateIsoDataVolume{
@@ -110,24 +117,43 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Config: b.config,
 			Client: b.client,
 		},
-		&StepCreateBootableVolume{
-			Config: b.config,
-			Client: b.client,
-		},
 	)
 
-	state := new(multistep.BasicStateBag)
-	state.Put("hook", hook)
-	state.Put("ui", ui)
+	if !b.config.SkipCreateImage {
+		steps = append(steps, &StepCreateBootableVolume{
+			Config:        b.config,
+			Client:        b.client,
+			GeneratedData: generatedData,
+		})
+	}
 
 	b.runner = commonsteps.NewRunner(steps, b.config.PackerConfig, ui)
 	b.runner.Run(ctx, state)
+
+	if rawErr, ok := state.GetOk("error"); ok {
+		return nil, rawErr.(error)
+	}
+	if _, ok := state.GetOk(multistep.StateCancelled); ok {
+		return nil, nil
+	}
+
+	if b.config.SkipCreateImage {
+		return nil, nil
+	}
 
 	bootableVolumeName, ok := state.Get("bootable_volume_name").(string)
 	if !ok || bootableVolumeName == "" {
 		return nil, fmt.Errorf("bootable volume name not found in state")
 	}
-	return &Artifact{Name: bootableVolumeName}, nil
+	namespace, _ := state.Get("bootable_volume_namespace").(string)
+
+	return &Artifact{
+		Name:      bootableVolumeName,
+		Namespace: namespace,
+		StateData: map[string]any{
+			"generated_data": state.Get("generated_data"),
+		},
+	}, nil
 }
 
 func (b *Builder) buildSSHSteps() ([]multistep.Step, []error) {

--- a/builder/kubevirt/iso/config.go
+++ b/builder/kubevirt/iso/config.go
@@ -136,6 +136,12 @@ type Config struct {
 	// However, it is recommended to set this to false in production environments to avoid
 	// resource leaks.
 	KeepVM bool `mapstructure:"keep_vm" required:"false"`
+
+	// SkipCreateImage when set to true skips creating the final bootable volume
+	// DataSource and does not register the artifact with HCP Packer. This is
+	// useful for iterative debugging when you do not want to produce a final image.
+	// Default is false.
+	SkipCreateImage bool `mapstructure:"skip_create_image" required:"false"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/kubevirt/iso/config.go
+++ b/builder/kubevirt/iso/config.go
@@ -86,6 +86,11 @@ type Config struct {
 	// OperatingSystemType is the type of operating system to install.
 	// Supported values are "linux" and "windows". Default is "linux".
 	OperatingSystemType string `mapstructure:"os_type" required:"false"`
+	// DiskBus is the bus type to use for CD-ROM disk devices on the temporary VM.
+	// Supported values are "scsi", "sata", and "virtio".
+	// Defaults to "scsi", which is compatible with both x86 and arm64 architectures.
+	// Use "sata" on x86 clusters if required by your storage configuration.
+	DiskBus string `mapstructure:"disk_bus" required:"false"`
 	// Networks is a list of networks to attach to the temporary VM.
 	// If no networks are specified, a single pod network will be used.
 	Networks []Network `mapstructure:"networks" required:"false"`
@@ -151,6 +156,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}, raws...)
 	if err != nil {
 		return nil, err
+	}
+
+	if c.DiskBus == "" {
+		c.DiskBus = "scsi"
 	}
 
 	for _, n := range c.Networks {

--- a/builder/kubevirt/iso/config.hcl2spec.go
+++ b/builder/kubevirt/iso/config.hcl2spec.go
@@ -28,6 +28,7 @@ type FlatConfig struct {
 	Preference              *string           `mapstructure:"preference" required:"true" cty:"preference" hcl:"preference"`
 	PreferenceKind          *string           `mapstructure:"preference_kind" required:"false" cty:"preference_kind" hcl:"preference_kind"`
 	OperatingSystemType     *string           `mapstructure:"os_type" required:"false" cty:"os_type" hcl:"os_type"`
+	DiskBus                 *string           `mapstructure:"disk_bus" required:"false" cty:"disk_bus" hcl:"disk_bus"`
 	Networks                []FlatNetwork     `mapstructure:"networks" required:"false" cty:"networks" hcl:"networks"`
 	MediaFiles              []string          `mapstructure:"media_files" required:"false" cty:"media_files" hcl:"media_files"`
 	BootCommand             []string          `mapstructure:"boot_command" required:"false" cty:"boot_command" hcl:"boot_command"`
@@ -80,6 +81,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"preference":                 &hcldec.AttrSpec{Name: "preference", Type: cty.String, Required: false},
 		"preference_kind":            &hcldec.AttrSpec{Name: "preference_kind", Type: cty.String, Required: false},
 		"os_type":                    &hcldec.AttrSpec{Name: "os_type", Type: cty.String, Required: false},
+		"disk_bus":                   &hcldec.AttrSpec{Name: "disk_bus", Type: cty.String, Required: false},
 		"networks":                   &hcldec.BlockListSpec{TypeName: "networks", Nested: hcldec.ObjectSpec((*FlatNetwork)(nil).HCL2Spec())},
 		"media_files":                &hcldec.AttrSpec{Name: "media_files", Type: cty.List(cty.String), Required: false},
 		"boot_command":               &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},

--- a/builder/kubevirt/iso/config.hcl2spec.go
+++ b/builder/kubevirt/iso/config.hcl2spec.go
@@ -47,6 +47,7 @@ type FlatConfig struct {
 	WinRMPassword           *string           `mapstructure:"winrm_password" required:"false" cty:"winrm_password" hcl:"winrm_password"`
 	WinRMWaitTimeout        *string           `mapstructure:"winrm_wait_timeout" required:"false" cty:"winrm_wait_timeout" hcl:"winrm_wait_timeout"`
 	KeepVM                  *bool             `mapstructure:"keep_vm" required:"false" cty:"keep_vm" hcl:"keep_vm"`
+	SkipCreateImage         *bool             `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -98,6 +99,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_password":             &hcldec.AttrSpec{Name: "winrm_password", Type: cty.String, Required: false},
 		"winrm_wait_timeout":         &hcldec.AttrSpec{Name: "winrm_wait_timeout", Type: cty.String, Required: false},
 		"keep_vm":                    &hcldec.AttrSpec{Name: "keep_vm", Type: cty.Bool, Required: false},
+		"skip_create_image":          &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/kubevirt/iso/resources.go
+++ b/builder/kubevirt/iso/resources.go
@@ -197,6 +197,7 @@ func getLinuxVirtualMachineDisks() []v1.Disk {
 			Name: "cdrom",
 			DiskDevice: v1.DiskDevice{
 				CDRom: &v1.CDRomTarget{
+					Bus:  "sata",
 					Tray: "closed",
 				},
 			},
@@ -206,6 +207,7 @@ func getLinuxVirtualMachineDisks() []v1.Disk {
 			Name: "oemdrv",
 			DiskDevice: v1.DiskDevice{
 				CDRom: &v1.CDRomTarget{
+					Bus:  "sata",
 					Tray: "closed",
 				},
 			},

--- a/builder/kubevirt/iso/resources.go
+++ b/builder/kubevirt/iso/resources.go
@@ -48,7 +48,8 @@ func virtualMachine(
 	preferenceName,
 	instanceTypeKind,
 	preferenceKind,
-	osType string,
+	osType,
+	diskBus string,
 	networks []Network) *v1.VirtualMachine {
 	var disks []v1.Disk
 	var volumes []v1.Volume
@@ -65,7 +66,7 @@ func virtualMachine(
 	}
 
 	if osType == "linux" {
-		disks = getLinuxVirtualMachineDisks()
+		disks = getLinuxVirtualMachineDisks(diskBus)
 		volumes = getLinuxVirtualMachineVolumes(name, isoVolumeName)
 	}
 
@@ -187,7 +188,7 @@ func sourceVolume(name, namespace, instanceType, preferenceName string) *cdiv1.D
 	}
 }
 
-func getLinuxVirtualMachineDisks() []v1.Disk {
+func getLinuxVirtualMachineDisks(diskBus string) []v1.Disk {
 	rootdisk := uint(1)
 	cdrom := uint(2)
 	oemdrv := uint(3)
@@ -197,7 +198,7 @@ func getLinuxVirtualMachineDisks() []v1.Disk {
 			Name: "cdrom",
 			DiskDevice: v1.DiskDevice{
 				CDRom: &v1.CDRomTarget{
-					Bus:  "sata",
+					Bus:  v1.DiskBus(diskBus),
 					Tray: "closed",
 				},
 			},
@@ -207,7 +208,7 @@ func getLinuxVirtualMachineDisks() []v1.Disk {
 			Name: "oemdrv",
 			DiskDevice: v1.DiskDevice{
 				CDRom: &v1.CDRomTarget{
-					Bus:  "sata",
+					Bus:  v1.DiskBus(diskBus),
 					Tray: "closed",
 				},
 			},

--- a/builder/kubevirt/iso/step_create_bootablevolume.go
+++ b/builder/kubevirt/iso/step_create_bootablevolume.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -15,8 +16,9 @@ import (
 )
 
 type StepCreateBootableVolume struct {
-	Config Config
-	Client kubecli.KubevirtClient
+	Config        Config
+	Client        kubecli.KubevirtClient
+	GeneratedData *packerbuilderdata.GeneratedData
 }
 
 func (s *StepCreateBootableVolume) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -49,6 +51,8 @@ func (s *StepCreateBootableVolume) Run(ctx context.Context, state multistep.Stat
 	}
 
 	state.Put("bootable_volume_name", ds.Name)
+	state.Put("bootable_volume_namespace", namespace)
+	s.GeneratedData.Put("BootableVolumeName", ds.Name)
 	return multistep.ActionContinue
 }
 

--- a/builder/kubevirt/iso/step_create_bootablevolume_test.go
+++ b/builder/kubevirt/iso/step_create_bootablevolume_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/packer-plugin-kubevirt/builder/kubevirt/iso"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 
 	fakecdiclient "kubevirt.io/client-go/containerizeddataimporter/fake"
 	"kubevirt.io/client-go/kubecli"
@@ -66,7 +67,8 @@ var _ = Describe("StepCreateBootableVolume", func() {
 				InstanceType: "cx1.large",
 				Preference:   "fedora",
 			},
-			Client: virtClient,
+			Client:        virtClient,
+			GeneratedData: &packerbuilderdata.GeneratedData{State: state},
 		}
 	})
 

--- a/builder/kubevirt/iso/step_create_virtualmachine.go
+++ b/builder/kubevirt/iso/step_create_virtualmachine.go
@@ -33,6 +33,7 @@ func (s *StepCreateVirtualMachine) Run(ctx context.Context, state multistep.Stat
 	preferenceName := s.Config.Preference
 	preferenceKind := s.Config.PreferenceKind
 	osType := s.Config.OperatingSystemType
+	diskBus := s.Config.DiskBus
 	networks := s.Config.Networks
 
 	if osType == "" || (osType != "linux" && osType != "windows") {
@@ -49,6 +50,7 @@ func (s *StepCreateVirtualMachine) Run(ctx context.Context, state multistep.Stat
 		instanceTypeKind,
 		preferenceKind,
 		osType,
+		diskBus,
 		networks)
 
 	ui.Sayf("Creating a new temporary VirtualMachine (%s/%s)...", namespace, name)

--- a/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
+++ b/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
@@ -9,6 +9,11 @@
 - `os_type` (string) - OperatingSystemType is the type of operating system to install.
   Supported values are "linux" and "windows". Default is "linux".
 
+- `disk_bus` (string) - DiskBus is the bus type to use for CD-ROM disk devices on the temporary VM.
+  Supported values are "scsi", "sata", and "virtio".
+  Defaults to "scsi", which is compatible with both x86 and arm64 architectures.
+  Use "sata" on x86 clusters if required by your storage configuration.
+
 - `networks` ([]Network) - Networks is a list of networks to attach to the temporary VM.
   If no networks are specified, a single pod network will be used.
 

--- a/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
+++ b/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
@@ -56,4 +56,9 @@
   However, it is recommended to set this to false in production environments to avoid
   resource leaks.
 
+- `skip_create_image` (bool) - SkipCreateImage when set to true skips creating the final bootable volume
+  DataSource and does not register the artifact with HCP Packer. This is
+  useful for iterative debugging when you do not want to produce a final image.
+  Default is false.
+
 <!-- End of code generated from the comments of the Config struct in builder/kubevirt/iso/config.go; -->


### PR DESCRIPTION
## Summary

This PR adds native HCP Packer registry integration to the `kubevirt-iso`
builder and fixes a pre-existing bug where Linux CD-ROM disk devices had no
bus type set, causing builds to fail on arm64 clusters.

---

## Changes

### 1. HCP Packer registry support (`10f464d`)

The `kubevirt-iso` builder now registers build artifacts with the HCP Packer
registry after each successful build. When a `hcp_packer_registry` block is
present in the template, Packer core will track the resulting `DataSource`
as a versioned artifact in the registry.

**`artifact.go`**
- Added `Namespace` and `StateData` fields to `Artifact`
- `Id()` now returns `namespace/name` (e.g. `images/fedora-42`) so HCP can
  track artifacts unambiguously across clusters
- `State()` handles the `registryimage.ArtifactStateURI` key
  (`"par.artifact.metadata"`) and returns a populated `*registryimage.Image`
  with `provider=kubevirt`, `region=<namespace>`, and labels including
  `namespace` and any values from `generated_data`

**`builder.go`**
- `Prepare()` returns `[]string{"BootableVolumeName"}` so provisioners can
  reference the artifact name at runtime via `build.BootableVolumeName`
- `Run()` wires `packerbuilderdata.GeneratedData` so generated values are
  accessible in provisioner interpolation
- Added post-runner `state.GetOk("error")` and `state.GetOk(StateCancelled)`
  checks before artifact construction — previously a halted build would return
  a misleading `"bootable volume name not found in state"` error instead of
  the real underlying error
- `StepCreateBootableVolume` is gated on `!SkipCreateImage` so the step is
  skipped when the flag is set

**`config.go`**
- Added `skip_create_image bool` — when `true`, skips the final
  `StepCreateBootableVolume` step and returns no artifact, which also
  suppresses HCP registration. Useful for iterative debugging without
  producing a final image.

**`step_create_bootablevolume.go`**
- Added `GeneratedData *packerbuilderdata.GeneratedData` field
- Calls `GeneratedData.Put("BootableVolumeName", ds.Name)` so the value is
  available to provisioners
- Stores `bootable_volume_namespace` in the state bag alongside the existing
  `bootable_volume_name` so `Builder.Run()` can construct a fully-qualified
  artifact ID

**`artifact_test.go`** (new)
- Table-driven unit tests covering `BuilderId`, `Id`, `String`, `Files`,
  `Destroy`, `State(ArtifactStateURI)` with and without `generated_data`,
  and `StateData` fallthrough including nil map safety

**`step_create_bootablevolume_test.go`**
- Wired `GeneratedData` into `BeforeEach` to prevent nil pointer panic

---

### 2. CD-ROM bus type — intermediate fix (`cde2306`)

During testing, KubeVirt's admission webhook rejected the VM because Linux
CD-ROM devices had no `Bus` set. KubeVirt was defaulting to `virtio`, which
is an invalid bus type for CD-ROM devices. This commit hardcoded `sata` as
a stepping stone; it was immediately superseded by commit `ef8f80d`.

---

### 3. Configurable CD-ROM bus type (`ef8f80d`)

The intermediate `sata` fix broke arm64 clusters (including OpenShift on
ARM), where the admission webhook only accepts `virtio` or `scsi` for disk
buses. Rather than hardcode either value, this commit exposes `disk_bus` as
a user-configurable field.

**`config.go`**
- Added `disk_bus string` field with `mapstructure:"disk_bus"`
- `Prepare()` defaults to `"scsi"` when unset — valid on both x86 and arm64

**`resources.go`**
- `getLinuxVirtualMachineDisks()` now accepts `diskBus string` and applies
  `v1.DiskBus(diskBus)` to both the `cdrom` and `oemdrv` CD-ROM devices
- Windows VM disks are unaffected (already explicitly set to `sata`)

**`step_create_virtualmachine.go`**
- Reads `s.Config.DiskBus` and passes it through to `virtualMachine()`

**Example usage in template:**
```hcl
source "kubevirt-iso" "example" {
  disk_bus = "scsi"   # arm64 clusters
  # disk_bus = "sata" # x86 clusters if needed
}
```

---

## What was tested

All existing unit tests pass. New unit tests for the HCP artifact wiring pass.

```
ok  github.com/hashicorp/packer-plugin-kubevirt/builder/kubevirt/iso  5.3s
```

End-to-end testing was carried out on a local minikube cluster (qemu2 driver,
Apple Silicon). The following was verified locally:

- `packer validate` accepts `hcp_packer_registry {}` and `skip_create_image`
- HCP credentials authenticate correctly (`Tracking build on HCP Packer with
  fingerprint ...` appears in build output)
- `StepValidateIsoDataVolume` reaches the cluster and validates the ISO
  DataVolume successfully
- `StepCopyMediaFiles` creates the ConfigMap successfully
- `StepCreateVirtualMachine` creates the VM with `disk_bus = "scsi"` without
  rejection from the admission webhook

End-to-end VM boot and full HCP artifact registration could not be completed
locally due to a minikube + Docker networking constraint (`nf_nat` table
operations are not permitted inside a Docker container, which prevents
KubeVirt's masquerade networking from initialising the VM's network stack).
This is an environment limitation, not a plugin issue.

## Remaining tests required before merge

The following must be run on a **Linux-based KubeVirt cluster** (bare metal,
OpenShift Local/CRC, or a cloud-hosted cluster):

### 1. Full build completes and registers with HCP

```sh
packer build hcp-test.pkr.hcl
```

**Expected:**
- Build runs to completion
- Terminal output contains:
  ```
  kubevirt-iso.test: Bootable volume: images/hcp-test-image
  ```
- HCP portal → Packer → Buckets → `kubevirt-test` → latest version shows:

| Field                     | Expected                |
| ---------------------------| -------------------------|
| Artifact ID               | `images/hcp-test-image` |
| Provider                  | `kubevirt`              |
| Region                    | `images`                |
| Label: namespace          | `images`                |
| Label: BootableVolumeName | `hcp-test-image`        |

### 2. `build.BootableVolumeName` is accessible in provisioners

Add to the build block:
```hcl
provisioner "shell" {
  inline = ["echo BootableVolumeName=${build.BootableVolumeName}"]
}
```

**Expected:** Provisioner output contains `BootableVolumeName=hcp-test-image`
and not the `ERR_*` placeholder.

### 3. Second build creates a new version

Change `name` to `hcp-test-image-2` and re-run.

**Expected:** HCP bucket shows 2 distinct versions.

### 4. Failed build is not registered

Set `iso_volume_name` to a DataVolume that does not exist and run.

**Expected:** Build exits non-zero, no new version in HCP bucket.

### 5. `skip_create_image = true` suppresses HCP registration

Add `skip_create_image = true` to the source block and run.

**Expected:** No `Creating a new bootable volume` log line, no artifact
output, no new version in HCP bucket.
